### PR TITLE
add retry for tile fetch and prediction api errors, add some error handling

### DIFF
--- a/ml_enabler/commands/fetch_predictions.py
+++ b/ml_enabler/commands/fetch_predictions.py
@@ -13,12 +13,13 @@ from ml_enabler.predictors.LookingGlassPredictor import LookingGlassPredictor
 @click.option('--token', help='Access token for tiles URL', default=None)
 @click.option('--concurrency', help='Number of simultaneous requests to make to prediction image', type=int, default=16)
 @click.option('--outfile', help='Filename to write results to', type=click.File('w'))
+@click.option('--errfile', help='Filename to write errors to', type=click.File('w'))
 @click.pass_context
-def fetch(ctx, bbox, tile_url, zoom, token, concurrency, outfile):
+def fetch(ctx, bbox, tile_url, zoom, token, concurrency, outfile, errfile):
     endpoint = ctx.obj['endpoint']
     predictor = LookingGlassPredictor(endpoint, tile_url, token)
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(predictor.predict(bbox, concurrency, outfile))
+    loop.run_until_complete(predictor.predict(bbox, concurrency, outfile, errfile))
     print('done processing tiles')
 
 

--- a/ml_enabler/exceptions.py
+++ b/ml_enabler/exceptions.py
@@ -1,0 +1,9 @@
+
+class InvalidData(Exception):
+    pass
+
+class InvalidModelResponse(Exception):
+    pass
+
+class ImageFetchError(Exception):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(
         'Click',
         'numpy',
         'mercantile==1.0.4',
-        'aiohttp==3.5.4'
+        'aiohttp==3.5.4',
+        'backoff==1.8.0'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Uses the `backoff` module to retry errors, adds some basic error handling and outputs errors into a separate file.

cc @geohacker 