### PR TITLE
Add metadata

### DIFF
--- a/ml_enabler/aggregators/BaseAggregator.py
+++ b/ml_enabler/aggregators/BaseAggregator.py
@@ -3,8 +3,10 @@ import json
 class BaseAggregator:
     
     def __init__(self, zoom, infile, outfile, errfile):
+        data = json.load(infile)
         self.zoom = zoom
-        self.source_data = json.load(infile)
+        self.source_data = data['predictions']
+        self.source_metadata = data['metadata']
         self.outfile = outfile
         self.errfile = errfile
 

--- a/ml_enabler/aggregators/LookingGlassAggregator.py
+++ b/ml_enabler/aggregators/LookingGlassAggregator.py
@@ -15,7 +15,11 @@ class LookingGlassAggregator(BaseAggregator):
         async with aiohttp.ClientSession(connector=conn, timeout=timeout) as session:
             futures = [self.get_values_for_quadkey(session, quadkey) for quadkey in agg_quadkeys]
             results = await asyncio.gather(*futures)
-            self.outfile.write(json.dumps(results, indent=2))
+            out_data = {
+                'metadata': self.source_metadata,
+                'predictions': results
+            }
+            self.outfile.write(json.dumps(out_data, indent=2))
             self.outfile.close()
 
     def get_agg_quadkeys(self):

--- a/ml_enabler/cli.py
+++ b/ml_enabler/cli.py
@@ -2,11 +2,11 @@ import click
 from ml_enabler.commands import fetch_predictions, aggregate_predictions
 
 @click.group()
-@click.option('--endpoint', default='http://localhost:8501/v1/models/looking_glass:predict')
+# @click.option('--endpoint', default='http://localhost:8501/v1/models/looking_glass:predict')
 @click.pass_context
-def main_group(ctx, endpoint):
+def main_group(ctx):
     ctx.obj = {}
-    ctx.obj['endpoint'] = endpoint
+    # ctx.obj['endpoint'] = endpoint
 
 main_group.add_command(fetch_predictions.fetch)
 main_group.add_command(aggregate_predictions.aggregate)

--- a/ml_enabler/commands/fetch_predictions.py
+++ b/ml_enabler/commands/fetch_predictions.py
@@ -3,6 +3,7 @@ import click
 from ml_enabler.predictors.LookingGlassPredictor import LookingGlassPredictor
 
 @click.command('fetch_predictions', short_help='Fetch model predictions for a bbox')
+@click.option('--endpoint', default='http://localhost:8501/v1/')
 @click.option('--bbox', help='Bounding box to fetch predictions for, as <left>,<bottom>,<right>,<top>')
 # @click.option('--tile-url', default='https://api.mapbox.com/v4/digitalglobe.2lnpeioh/{z}/{x}/{y}.jpg?access_token={token}')
 @click.option('--tile-url',
@@ -16,8 +17,7 @@ from ml_enabler.predictors.LookingGlassPredictor import LookingGlassPredictor
 @click.option('--outfile', help='Filename to write results to', type=click.File('w'))
 @click.option('--errfile', help='Filename to write errors to', type=click.File('w'))
 @click.pass_context
-def fetch(ctx, bbox, tile_url, zoom, token, lg_weight, concurrency, outfile, errfile):
-    endpoint = ctx.obj['endpoint']
+def fetch(ctx, endpoint, bbox, tile_url, zoom, token, lg_weight, concurrency, outfile, errfile):
     model_opts = {
         'weight': lg_weight
     }


### PR DESCRIPTION
This PR adds a `metadata` property to the JSON output which contains `model_name` and `version`.

This also switches the `--endpoint` parameter to the subcommand rather than the main command, and changes the endpoint format to something like `http://localhost:8501/v1/` rather than `http://localhost:8501/v1/models/looking_glass:predict`.

cc @geohacker 