### PR TITLE
Upload predictions

### DIFF
--- a/ml_enabler/aggregators/LookingGlassAggregator.py
+++ b/ml_enabler/aggregators/LookingGlassAggregator.py
@@ -42,8 +42,6 @@ class LookingGlassAggregator(BaseAggregator):
             'centroid': get_tile_center(tile),
             'predictions': {
                 'ml_prediction': total_ml_building_area,
-                'osm_building_area': osm_building_area,
-                'difference': total_ml_building_area / osm_building_area
-                # 'difference': total_ml_building_area / osm_building_area
+                'osm_building_area': osm_building_area
             }
         }

--- a/ml_enabler/cli.py
+++ b/ml_enabler/cli.py
@@ -1,5 +1,5 @@
 import click
-from ml_enabler.commands import fetch_predictions, aggregate_predictions
+from ml_enabler.commands import fetch_predictions, aggregate_predictions, upload_predictions
 
 @click.group()
 # @click.option('--endpoint', default='http://localhost:8501/v1/models/looking_glass:predict')
@@ -10,3 +10,4 @@ def main_group(ctx):
 
 main_group.add_command(fetch_predictions.fetch)
 main_group.add_command(aggregate_predictions.aggregate)
+main_group.add_command(upload_predictions.upload)

--- a/ml_enabler/commands/upload_predictions.py
+++ b/ml_enabler/commands/upload_predictions.py
@@ -1,10 +1,25 @@
 import click
 import json
+from ml_enabler.utils.api import get_model_id, post_prediction, post_prediction_tiles
 
-@click.command('aggregate_predictions', short_help='Aggregate predictions to lower zoom levels and add ancillary data')
+@click.command('upload_predictions', short_help='Upload predictions JSON to the ML Enabler API')
 @click.option('--infile', help='Filename to read predictions JSON from', type=click.File('r'))
-@click.option('--api-url', help='ML Enabler API URL', default='http://localhost:8000/')
+@click.option('--api-url', help='ML Enabler API URL', default='http://localhost:5000/')
 @click.pass_context
 def upload(ctx, infile, api_url):
+    data = json.load(infile)
+    metadata = data['metadata']
+    predictions = data['predictions']
+    model_name = metadata['model_name']
+    model_id = get_model_id(api_url, model_name)
+    bbox = metadata['bbox']
+    version = metadata['version']
+    prediction_id = post_prediction(api_url, model_id, version, bbox)
+    for p in predictions:
+        p['prediction_id'] = prediction_id
+    post_prediction_tiles(api_url, prediction_id, predictions)
+    print(f'uploaded predictions to model_id={model_id}, prediction_id={prediction_id}')
 
+
+    
     

--- a/ml_enabler/commands/upload_predictions.py
+++ b/ml_enabler/commands/upload_predictions.py
@@ -1,0 +1,10 @@
+import click
+import json
+
+@click.command('aggregate_predictions', short_help='Aggregate predictions to lower zoom levels and add ancillary data')
+@click.option('--infile', help='Filename to read predictions JSON from', type=click.File('r'))
+@click.option('--api-url', help='ML Enabler API URL', default='http://localhost:8000/')
+@click.pass_context
+def upload(ctx, infile, api_url):
+
+    

--- a/ml_enabler/predictors/LookingGlassPredictor.py
+++ b/ml_enabler/predictors/LookingGlassPredictor.py
@@ -29,7 +29,8 @@ class LookingGlassPredictor(BasePredictor):
             version = await self.get_version(session)
             metadata = {
                 'model_name': self.name,
-                'version': version
+                'version': version,
+                'bbox': bbox
             }
             futures = [self.predict_tile(session, tile, weight) for tile in tiles]
             results = await asyncio.gather(*futures)

--- a/ml_enabler/utils/api.py
+++ b/ml_enabler/utils/api.py
@@ -1,0 +1,42 @@
+import requests
+from os.path import join
+import json
+
+def get_model_id(api_url, model_name):
+    url = f'{api_url}/model/all'
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise Exception('Failed to fetch model id for model name')
+    data = response.json()
+    for model in data:
+        if model['name'] == model_name:
+            return model['modelId']
+    raise Exception('Model with that name does not exist')
+
+def post_prediction(api_url, model_id, version, bbox):
+    url = f'{api_url}/model/{model_id}/prediction'
+    data = {
+        'version': f'{version}.0.0',
+        'modelId': model_id,
+        'bbox': bbox.split(','),
+        'tileZoom': 14 # FIXME:
+    }
+    print(data)
+    response = requests.post(url, json=data)
+    if response.status_code != 200:
+        raise Exception('could not POST Prediction')
+    response_data = response.json()
+    return response_data['prediction_id']
+
+def post_prediction_tiles(api_url, prediction_id, predictions):
+    url = f'{api_url}/model/prediction/{prediction_id}/tiles'
+    data = {
+        'predictionId': prediction_id,
+        'predictions': predictions
+    }
+    response = requests.post(url, json=data)
+    import pdb;pdb.set_trace()
+    if response.status_code != 200:
+        raise Exception('Error posting tiles for prediction')
+    return True
+

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     install_requires=[
         'Click',
         'numpy',
+        'requests==2.22.0',
         'mercantile==1.0.4',
         'aiohttp==3.5.4',
         'backoff==1.8.0',


### PR DESCRIPTION
Command to `upload_predictions`:

Usage example:
`ml-enabler upload_predictions --api-url http://localhost:5000 --infile aggregated_tiles.json`

This will get the `model_id` and `version` from the `metadata` supplied in the JSON of the `infile`. It will create a new Prediction in the API and upload predictions from the JSON to it.

cc @geohacker