### PR TITLE
add Predictor for model mapwithai_road_stats

### DIFF
--- a/ml_enabler/predictors/MapWithAIRoadStatsPredictor.py
+++ b/ml_enabler/predictors/MapWithAIRoadStatsPredictor.py
@@ -1,0 +1,63 @@
+import mercantile
+import aiohttp
+import asyncio
+import logging
+import json
+from .BasePredictor import BasePredictor
+from ml_enabler.utils import get_tile_quadkey, bbox_to_tiles, get_tile_center, clip_polygon
+from area import area
+
+
+class MapWithAIRoadStatsPredictor(BasePredictor):
+    default_zoom = 16
+    name = 'mapwithai_road_stats'
+
+    async def predict(self, bbox, concurrency, outfile, errfile):
+        """
+        Returns MapWithAI road stats for the given bbox and tile zoom
+        """
+
+        tiles = list(bbox_to_tiles(bbox, self.zoom))
+        logging.info(f'Processing {len(tiles)} tiles')
+        metadata = {
+            'model_name': self.name,
+            'version': '1.0.0',
+            'bbox': bbox,
+            'zoom': self.zoom
+        }
+        conn = aiohttp.TCPConnector(limit=concurrency)
+        timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
+        async with aiohttp.ClientSession(connector=conn, timeout=timeout) as session:
+            futures = [self.predict_tile(session, tile) for tile in tiles]
+            results = await asyncio.gather(*futures)
+            data = {
+                'metadata': metadata,
+                'predictions': results
+            }
+            outfile.write(json.dumps(data, indent=2))
+            outfile.close()
+
+
+    async def predict_tile(self, session, tile):
+        quadkey = get_tile_quadkey(tile)
+        bounds = list(mercantile.bounds(tile))
+        bbox_str = ','.join(map(str, bounds))
+        tile_url = f'{self.tile_url}&bbox={bbox_str}'
+
+        try:
+            res = await session.get(tile_url)
+            if res.status != 200:
+                logging.warning(f'Unable to fetch tile {tile_url}')
+                raise Exception(f'Unable to fetch tile {tile_url}')
+
+            data = await res.json()
+            return {
+                'quadkey': quadkey,
+                'centroid': get_tile_center(tile),
+                'predictions': {
+                    'ml_prediction': data['road_length_km']['total'],
+                    'url': tile_url,
+                }
+            }
+        except Exception as e:
+            logging.error(str(e))

--- a/ml_enabler/predictors/__init__.py
+++ b/ml_enabler/predictors/__init__.py
@@ -1,8 +1,10 @@
 from ml_enabler.predictors.LookingGlassPredictor import LookingGlassPredictor
 from ml_enabler.predictors.BuildingPredictor import BuildingPredictor
+from ml_enabler.predictors.MapWithAIRoadStatsPredictor import MapWithAIRoadStatsPredictor
 
 
 predictors = {
   'looking_glass': LookingGlassPredictor,
-  'building_api': BuildingPredictor
+  'building_api': BuildingPredictor,
+  'mapwithai_road_stats': MapWithAIRoadStatsPredictor
 }


### PR DESCRIPTION
Added a new predictor for fetching ML road stats from the Map With AI
web service. The returned stats are based on "extra" ML roads that
are complimentary to what already exist on OSM. Example result for
a zoom-16 tile:

https://www.facebook.com/maps/ml_roads?result_type=road_stats&theme=ml_road_vector&collaborator=fbid&token=ASZUVdYpCkd3M6ZrzjXdQzHulqRMnxdlkeBJWEKOeTUoY_Gwm9fuEd2YObLrClgDB_xfavizBsh0oDfTWTF7Zb4C&hash=ASYM8LPNy8k1XoJiI7A&bbox=7.5640869140625,12.870714867860165,7.569580078125,12.876069959946498

Example usage:

./env/bin/ml-enabler fetch_predictions --name mapwithai_road_stats \
--bbox "7.558388, 12.798083, 7.727908, 12.931749" \
--endpoint "https://ml-enabler.hotosm.org/v1/" \
--zoom 16 --outfile ../ml-enabler-data/model_5_assisted_proj6_pred.json \
--errfile ../ml-enabler-data/model_5_assisted_proj6_err.json \
--tile-url "https://www.facebook.com/maps/ml_roads?result_type=road_stats&theme=ml_road_vector&collaborator=fbid&token=ASZUVdYpCkd3M6ZrzjXdQzHulqRMnxdlkeBJWEKOeTUoY_Gwm9fuEd2YObLrClgDB_xfavizBsh0oDfTWTF7Zb4C&hash=ASYM8LPNy8k1XoJiI7A"

Tested with the command above and uploaded predictions to model 5 on https://ml-enabler.hotosm.org/v1/