### PR TITLE
Mapwithai road stats aggregator

### DIFF
--- a/ml_enabler/aggregators/MapWithAIRoadStatsAggregator.py
+++ b/ml_enabler/aggregators/MapWithAIRoadStatsAggregator.py
@@ -1,0 +1,52 @@
+from ml_enabler.aggregators.BaseAggregator import BaseAggregator
+from ml_enabler.utils import get_road_len_km, get_tile_center
+import functools
+import mercantile
+import aiohttp
+import asyncio
+import json
+
+
+class MapWithAIRoadStatsAggregator(BaseAggregator):
+    async def aggregate(self):
+        agg_quadkeys = self.get_agg_quadkeys()
+        conn = aiohttp.TCPConnector(limit=3)  # FIXME: make concurrency a param
+        timeout = aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)
+        async with aiohttp.ClientSession(connector=conn, timeout=timeout) as session:
+            futures = [self.get_values_for_quadkey(session, quadkey) for quadkey in agg_quadkeys]
+            results = await asyncio.gather(*futures)
+            self.source_metadata['zoom'] = self.zoom
+            out_data = {
+                'metadata': self.source_metadata,
+                'predictions': results
+            }
+            self.outfile.write(json.dumps(out_data, indent=2))
+            self.outfile.close()
+
+    def get_agg_quadkeys(self):
+        '''
+            Returns the list of unique quadkeys in the dataset at the destination zoom level
+        '''
+        all_quadkeys = [d['quadkey'] for d in self.source_data]
+        return list(set([q[0:self.zoom] for q in all_quadkeys]))
+
+    async def get_values_for_quadkey(self, session, quadkey):
+        '''
+            Returns consolidated data values for a quadkey
+        '''
+        filtered_quadkeys = list(
+            filter(lambda d: d['quadkey'].startswith(quadkey), self.source_data))
+        total_ml_road_len_km = functools.reduce(
+            lambda a, b: (a + b['predictions']['ml_prediction']),
+            filtered_quadkeys,
+            0)
+        tile = mercantile.quadkey_to_tile(quadkey)
+        osm_road_len_km = await get_road_len_km(session, tile, self.overpass_url)
+        return {
+            'quadkey': quadkey,
+            'centroid': get_tile_center(tile),
+            'predictions': {
+                'ml_prediction': total_ml_road_len_km,
+                'osm_road_len_km': osm_road_len_km,
+            }
+        }

--- a/ml_enabler/aggregators/__init__.py
+++ b/ml_enabler/aggregators/__init__.py
@@ -1,7 +1,9 @@
 from ml_enabler.aggregators.BuildingAggregator import BuildingAggregator
 from ml_enabler.aggregators.LookingGlassAggregator import LookingGlassAggregator
+from ml_enabler.aggregators.MapWithAIRoadStatsAggregator import MapWithAIRoadStatsAggregator
 
 aggregators = {
   'looking_glass': LookingGlassAggregator,
-  'building_api': BuildingAggregator
+  'building_api': BuildingAggregator,
+  'mapwithai_road_stats': MapWithAIRoadStatsAggregator,
 }

--- a/ml_enabler/tests/fixtures/mapwithai_api_response.json
+++ b/ml_enabler/tests/fixtures/mapwithai_api_response.json
@@ -1,0 +1,10 @@
+{
+   "road_count": {
+      "total": 1,
+      "residential": 1
+   },
+   "road_length_km": {
+      "total": 0.96773922925188,
+      "residential": 0.96773922925188
+   }
+}

--- a/ml_enabler/tests/fixtures/mapwithai_road_stats_aggregator_expected.json
+++ b/ml_enabler/tests/fixtures/mapwithai_road_stats_aggregator_expected.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "model_name": "mapwithai_road_stats",
+    "version": "1.0.0",
+    "bbox": "7.5613403, 12.910875, 7.566833, 12.916229",
+    "zoom": 15
+  },
+  "predictions": [
+    {
+      "quadkey": "122203212132220",
+      "centroid": "SRID=4326;POINT (7.564086914062501 12.91355234124947)",
+      "predictions": {
+        "ml_prediction": 3.87095691700752,
+        "osm_road_len_km": 28.485968068985457
+      }
+    }
+  ]
+}

--- a/ml_enabler/tests/fixtures/mapwithai_road_stats_fetch_expected.json
+++ b/ml_enabler/tests/fixtures/mapwithai_road_stats_fetch_expected.json
@@ -1,0 +1,42 @@
+{
+  "metadata": {
+    "model_name": "mapwithai_road_stats",
+    "version": "1.0.0",
+    "bbox": "7.5613403, 12.910875, 7.566833, 12.916229",
+    "zoom": 16
+  },
+  "predictions": [
+    {
+      "quadkey": "1222032121322200",
+      "centroid": "SRID=4326;POINT (7.561340332031249 12.91622948639482)",
+      "predictions": {
+        "ml_prediction": 0.96773922925188,
+        "url": "http://localhost:1234/mapwithai?test=true&bbox=7.55859375,12.913552398609207,7.5640869140625,12.91890657418042"
+      }
+    },
+    {
+      "quadkey": "1222032121322202",
+      "centroid": "SRID=4326;POINT (7.56134033203125 12.91087525346386)",
+      "predictions": {
+        "ml_prediction": 0.96773922925188,
+        "url": "http://localhost:1234/mapwithai?test=true&bbox=7.55859375,12.908198108318514,7.5640869140625,12.913552398609207"
+      }
+    },
+    {
+      "quadkey": "1222032121322201",
+      "centroid": "SRID=4326;POINT (7.566833496093751 12.91622948639482)",
+      "predictions": {
+        "ml_prediction": 0.96773922925188,
+        "url": "http://localhost:1234/mapwithai?test=true&bbox=7.5640869140625,12.913552398609207,7.569580078125,12.91890657418042"
+      }
+    },
+    {
+      "quadkey": "1222032121322203",
+      "centroid": "SRID=4326;POINT (7.566833496093749 12.91087525346386)",
+      "predictions": {
+        "ml_prediction": 0.96773922925188,
+        "url": "http://localhost:1234/mapwithai?test=true&bbox=7.5640869140625,12.908198108318514,7.569580078125,12.913552398609207"
+      }
+    }
+  ]
+}

--- a/ml_enabler/tests/fixtures/overpass_response_road.xml
+++ b/ml_enabler/tests/fixtures/overpass_response_road.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="CGImap 0.7.5 (3006 thorn-01.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+ <bounds minlat="12.9135524" minlon="7.5640869" maxlat="12.9189066" maxlon="7.5695801"/>
+ <node id="6661683055" visible="true" version="1" changeset="72823553" timestamp="2019-07-30T17:43:14Z" user="Nahorp" uid="10069087" lat="12.9174002" lon="7.5709935"/>
+ <node id="6666496857" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9143355" lon="7.5618821"/>
+ <node id="6666496883" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9167324" lon="7.5607926"/>
+ <node id="6666496884" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9170053" lon="7.5609913"/>
+ <node id="6666505285" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9173872" lon="7.5616318"/>
+ <node id="6666505286" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9176773" lon="7.5620989"/>
+ <node id="6666505287" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9183309" lon="7.5624380"/>
+ <node id="6666505288" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9187862" lon="7.5626715"/>
+ <node id="6666505289" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9190285" lon="7.5627619"/>
+ <node id="6666505290" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9192195" lon="7.5631085"/>
+ <node id="6666505291" visible="true" version="1" changeset="72865511" timestamp="2019-07-31T16:52:17Z" user="Nahorp" uid="10069087" lat="12.9195022" lon="7.5634325"/>
+ <node id="6666505292" visible="true" version="2" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9197415" lon="7.5638766"/>
+ <node id="6666506867" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9146051" lon="7.5622191"/>
+ <node id="6666506868" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9149723" lon="7.5626222"/>
+ <node id="6666506869" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9151302" lon="7.5630026"/>
+ <node id="6666506870" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9154570" lon="7.5633229"/>
+ <node id="6666506871" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9157802" lon="7.5635263"/>
+ <node id="6666506872" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9160409" lon="7.5637862"/>
+ <node id="6666506873" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9163677" lon="7.5639332"/>
+ <node id="6666506874" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9166613" lon="7.5641466"/>
+ <node id="6666506875" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9169878" lon="7.5642377"/>
+ <node id="6666506876" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9171367" lon="7.5641731"/>
+ <node id="6666506877" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9176751" lon="7.5641731"/>
+ <node id="6666506878" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9184083" lon="7.5641819"/>
+ <node id="6666506879" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9187835" lon="7.5640702"/>
+ <node id="6666506880" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9192216" lon="7.5641584"/>
+ <node id="6666506881" visible="true" version="2" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9196423" lon="7.5640989"/>
+ <node id="6666506882" visible="true" version="2" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9197406" lon="7.5639535"/>
+ <node id="6666512391" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9144807" lon="7.5620635"/>
+ <node id="6666512404" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9171986" lon="7.5613154"/>
+ <node id="6666512413" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9147516" lon="7.5640950"/>
+ <node id="6666512414" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9148646" lon="7.5645973"/>
+ <node id="6666512415" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9148646" lon="7.5648147"/>
+ <node id="6666512416" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9147893" lon="7.5649837"/>
+ <node id="6666512417" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9147893" lon="7.5653218"/>
+ <node id="6666512418" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9149776" lon="7.5656551"/>
+ <node id="6666512419" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9152554" lon="7.5663748"/>
+ <node id="6666512420" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9155426" lon="7.5667902"/>
+ <node id="6666512421" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9158909" lon="7.5671863"/>
+ <node id="6666512422" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9160793" lon="7.5679929"/>
+ <node id="6666512423" visible="true" version="1" changeset="72865667" timestamp="2019-07-31T16:56:22Z" user="Nahorp" uid="10069087" lat="12.9165736" lon="7.5690169"/>
+ <node id="6666517432" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9136676" lon="7.5692515"/>
+ <node id="6666517433" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9138634" lon="7.5693424"/>
+ <node id="6666517434" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9139698" lon="7.5693923"/>
+ <node id="6666517435" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9151992" lon="7.5699448"/>
+ <node id="6666517436" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9153716" lon="7.5700138"/>
+ <node id="6666517437" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9155403" lon="7.5700690"/>
+ <node id="6666517438" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9158213" lon="7.5701872"/>
+ <node id="6666517439" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9160907" lon="7.5703738"/>
+ <node id="6666517440" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9161828" lon="7.5704519"/>
+ <node id="6666517441" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9163852" lon="7.5705324"/>
+ <node id="6666517442" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9170881" lon="7.5708627"/>
+ <node id="6666517443" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9176804" lon="7.5711126"/>
+ <node id="6666517444" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9182063" lon="7.5713516"/>
+ <node id="6666517445" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9188223" lon="7.5715702"/>
+ <node id="6666517446" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9192712" lon="7.5717717"/>
+ <node id="6666517447" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9198993" lon="7.5720530"/>
+ <node id="6666517448" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9205892" lon="7.5723584"/>
+ <node id="6666517449" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9129689" lon="7.5689739"/>
+ <node id="6666517464" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9167855" lon="7.5698416"/>
+ <node id="6666517465" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9170206" lon="7.5705610"/>
+ <node id="6666517466" visible="true" version="1" changeset="72865943" timestamp="2019-07-31T17:05:13Z" user="Nahorp" uid="10069087" lat="12.9169241" lon="7.5707856"/>
+ <node id="6670477289" visible="true" version="3" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9104105" lon="7.5680369"/>
+ <node id="6670477290" visible="true" version="2" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9106138" lon="7.5680477"/>
+ <node id="6670477291" visible="true" version="2" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9106916" lon="7.5680505"/>
+ <node id="6725052581" visible="true" version="1" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9197254" lon="7.5640053"/>
+ <node id="6725052582" visible="true" version="1" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9197176" lon="7.5638086"/>
+ <node id="6725052583" visible="true" version="1" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9195827" lon="7.5641151"/>
+ <node id="6725052584" visible="true" version="1" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9196930" lon="7.5640560"/>
+ <node id="6725179587" visible="true" version="1" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029" lat="12.9107777" lon="7.5680624"/>
+ <way id="709291017" visible="true" version="4" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029">
+  <nd ref="6666496883"/>
+  <nd ref="6666496884"/>
+  <nd ref="6666512404"/>
+  <nd ref="6666505285"/>
+  <nd ref="6666505286"/>
+  <nd ref="6666505287"/>
+  <nd ref="6666505288"/>
+  <nd ref="6666505289"/>
+  <nd ref="6666505290"/>
+  <nd ref="6666505291"/>
+  <nd ref="6725052582"/>
+  <nd ref="6666505292"/>
+  <nd ref="6666506882"/>
+  <nd ref="6725052581"/>
+  <nd ref="6725052584"/>
+  <nd ref="6666506881"/>
+  <nd ref="6725052583"/>
+  <nd ref="6666506880"/>
+  <nd ref="6666506879"/>
+  <nd ref="6666506878"/>
+  <nd ref="6666506877"/>
+  <nd ref="6666506876"/>
+  <nd ref="6666506875"/>
+  <nd ref="6666506874"/>
+  <nd ref="6666506873"/>
+  <nd ref="6666506872"/>
+  <nd ref="6666506871"/>
+  <nd ref="6666506870"/>
+  <nd ref="6666506869"/>
+  <nd ref="6666506868"/>
+  <nd ref="6666506867"/>
+  <nd ref="6666512391"/>
+  <nd ref="6666496857"/>
+  <tag k="highway" v="track"/>
+  <tag k="source" v="FB Maxar"/>
+  <tag k="surface" v="unpaved"/>
+ </way>
+ <way id="709291704" visible="true" version="2" changeset="73278669" timestamp="2019-08-12T18:08:32Z" user="VLD017" uid="6606298">
+  <nd ref="6666512413"/>
+  <nd ref="6666512414"/>
+  <nd ref="6666512415"/>
+  <nd ref="6666512416"/>
+  <nd ref="6666512417"/>
+  <nd ref="6666512418"/>
+  <nd ref="6666512419"/>
+  <nd ref="6666512420"/>
+  <nd ref="6666512421"/>
+  <nd ref="6666512422"/>
+  <nd ref="6666512423"/>
+  <tag k="highway" v="track"/>
+  <tag k="source" v="FB Maxar"/>
+  <tag k="surface" v="unpaved"/>
+ </way>
+ <way id="709292998" visible="true" version="2" changeset="73515408" timestamp="2019-08-19T21:19:59Z" user="VLD052" uid="7610029">
+  <nd ref="6666517448"/>
+  <nd ref="6666517447"/>
+  <nd ref="6666517446"/>
+  <nd ref="6666517445"/>
+  <nd ref="6666517444"/>
+  <nd ref="6666517443"/>
+  <nd ref="6661683055"/>
+  <nd ref="6666517442"/>
+  <nd ref="6666517466"/>
+  <nd ref="6666517441"/>
+  <nd ref="6666517440"/>
+  <nd ref="6666517439"/>
+  <nd ref="6666517438"/>
+  <nd ref="6666517437"/>
+  <nd ref="6666517436"/>
+  <nd ref="6666517435"/>
+  <nd ref="6666517434"/>
+  <nd ref="6666517433"/>
+  <nd ref="6666517432"/>
+  <nd ref="6666517449"/>
+  <nd ref="6725179587"/>
+  <nd ref="6670477291"/>
+  <nd ref="6670477290"/>
+  <nd ref="6670477289"/>
+  <tag k="highway" v="track"/>
+  <tag k="source" v="digitalglobe"/>
+  <tag k="surface" v="unpaved"/>
+ </way>
+ <way id="709293000" visible="true" version="2" changeset="73277967" timestamp="2019-08-12T17:40:45Z" user="VLD017" uid="6606298">
+  <nd ref="6666512423"/>
+  <nd ref="6666517464"/>
+  <nd ref="6666517465"/>
+  <nd ref="6666517466"/>
+  <tag k="highway" v="track"/>
+  <tag k="source" v="FB Maxar"/>
+  <tag k="surface" v="unpaved"/>
+ </way>
+</osm>

--- a/ml_enabler/tests/test_aggregator.py
+++ b/ml_enabler/tests/test_aggregator.py
@@ -55,3 +55,42 @@ def test_building_aggregator():
     assert(result.exit_code) == 0
     assert(expected_results == current_results)
     os.remove('/tmp/aggregator.json')
+
+
+def test_mapwithai_road_stats_aggregator():
+
+    def overpass_callback():
+        overpass_response = open('ml_enabler/tests/fixtures/overpass_response_road.xml').read()
+        return overpass_response
+
+    server = MockServer(port=1234)
+    server.start()
+    server.add_callback_response('/api/interpreter', overpass_callback)
+    infile = 'ml_enabler/tests/fixtures/mapwithai_road_stats_fetch_expected.json'
+    expected_results = json.load(open('ml_enabler/tests/fixtures/mapwithai_road_stats_aggregator_expected.json'))
+    outfile = '/tmp/aggregator.json'
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        [
+            'aggregate_predictions',
+            '--name',
+            'mapwithai_road_stats',
+            '--zoom',
+            15,
+            '--infile',
+            infile,
+            '--outfile',
+            outfile,
+            '--overpass-url',
+            'http://localhost:1234/api/interpreter'
+        ]
+    )
+    current_results = json.load(open(outfile))
+    expected_results['predictions'] = sorted(expected_results['predictions'], key=lambda p: p['quadkey'])
+    current_results['predictions'] = sorted(current_results['predictions'], key=lambda p: p['quadkey'])
+    server.shutdown_server()
+    assert(result.exit_code == 0)
+    assert(expected_results == current_results)
+    os.remove('/tmp/aggregator.json')

--- a/ml_enabler/tests/test_fetch.py
+++ b/ml_enabler/tests/test_fetch.py
@@ -101,3 +101,47 @@ def test_building_api_fetch():
     os.remove(outfile)
     assert(result.exit_code == 0)
     assert(current_results == expected_results)
+
+
+def test_mapwithai_road_stats_fetch():
+    server = MockServer(port=1234)
+    server.start()
+    mapwithai_api_response = json.load(open('ml_enabler/tests/fixtures/mapwithai_api_response.json'))
+    server.add_json_response('/mapwithai', mapwithai_api_response)
+    outfile = '/tmp/predict_fetch.json'
+    errfile = '/tmp/err.json'
+    endpoint = 'http://localhost:1234/v1/'
+    tile_url = 'http://localhost:1234/mapwithai?test=true'
+    runner = CliRunner()
+    result = runner.invoke(
+        main_group,
+        [
+            'fetch_predictions',
+            '--name',
+            'mapwithai_road_stats',
+            '--zoom',
+            16,
+            '--concurrency',
+            1,
+            '--bbox',
+            '7.5613403, 12.910875, 7.566833, 12.916229',
+            '--token',
+            'abc',
+            '--outfile',
+            outfile,
+            '--errfile',
+            errfile,
+            '--endpoint',
+            endpoint,
+            '--tile-url',
+            tile_url
+        ]
+    )
+    current_results = json.load(open(outfile))
+    expected_results = json.load(open('ml_enabler/tests/fixtures/mapwithai_road_stats_fetch_expected.json'))
+    expected_results['predictions'] = sorted(expected_results['predictions'], key=lambda p: p['quadkey'])
+    current_results['predictions'] = sorted(current_results['predictions'], key=lambda p: p['quadkey'])
+    server.shutdown_server()
+    os.remove(outfile)
+    assert(result.exit_code == 0)
+    assert(current_results == expected_results)

--- a/ml_enabler/utils/__init__.py
+++ b/ml_enabler/utils/__init__.py
@@ -23,6 +23,11 @@ async def get_building_area(session, tile, overpass_url):
     return await OSMData(geojson, overpass_url).building_area(session)
 
 
+async def get_road_len_km(session, tile, overpass_url):
+    geojson = mercantile.feature(tile)
+    return await OSMData(geojson, overpass_url).road_length_km(session)
+
+
 def tile_to_geojson(tile):
     return mercantile.feature(tile)
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     install_requires=[
         'Click',
         'numpy',
+        'geopy',
         'requests==2.22.0',
         'mercantile==1.0.4',
         'aiohttp==3.5.4',


### PR DESCRIPTION
1. Added aggregator for Map With AI road stats
2. Use osm_road_len_km  rather than building area in the aggregated results. Imported the geopy library to compute road length in km.
3. Added tests for predictor and aggregator of Map With AI road stats. Both tests are passing.